### PR TITLE
修复HomeHero组件移动端下出现横向滚动条的bug

### DIFF
--- a/packages/cli/doc-core/src/theme-default/components/HomeHero/index.module.scss
+++ b/packages/cli/doc-core/src/theme-default/components/HomeHero/index.module.scss
@@ -13,7 +13,8 @@
     180deg,
     #42d392 1turn
   );
-  width: 500px;
+  max-width: 500px;
+  width: 100%;
   height: 500px;
   border-radius: 100%;
   mixblendmode: normal;


### PR DESCRIPTION
修复HomeHero组件移动端下出现横向滚动条的bug

## Summary

在移动端下，出现了更显滚动条，经过定位发现是一个css样式的问题；
在组件HomeHero的样式里面


copilot:summary

## Details

<!-- The details can be generated automatically by GitHub Copilot, so you don't have to do anything. -->
<!-- If you want to write it manually, remove the "copilot:walkthrough" placeholder. -->

copilot:walkthrough

## Related Issue

<!--- Provide link of related issues -->

## Checklist

- [x ] 我更新了HomeHero组件的index.module.scss 文件
